### PR TITLE
Minor changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The options are:
 
 - `rootTypeUrl: string`: Defines the root type message to encode/decode messages. Required.
 - `options: Object`
+  - `verify: boolean`: Verify the objects before to encode. Default: `true`.
   - `recursive: boolean`: Recursively decode the buffer. Default: `true`.
   - `strict: boolean`: Throw an exception if the type is not found. Default: `true`.
 

--- a/src/codec-protobuf.js
+++ b/src/codec-protobuf.js
@@ -176,18 +176,13 @@ export class Codec {
         return value;
       }
 
-      // If is the root object, we cannot use __type_url.
-      if (!parentProp && value.__type_url) {
-        return;
-      }
-
       // Encoding an any type object
       if (!value.__type_url) {
         return;
       }
 
-      if (type.fields[parentProp].type !== 'google.protobuf.Any') {
-        throw new Error(`Invalid __type_url for a non google.protobuf.Any: ${type.name}.${parentProp}`);
+      if (!parentProp || type.fields[parentProp].type !== 'google.protobuf.Any') {
+        throw new Error(`Invalid __type_url for a non google.protobuf.Any: ${type.name}${parentProp ? '.' + parentProp : ''}`);
       }
 
       const { __type_url: typeUrl, ...formalValue } = value;

--- a/src/codec-protobuf.js
+++ b/src/codec-protobuf.js
@@ -178,9 +178,10 @@ export class Codec {
 
       // If is the root object, we cannot use __type_url.
       if (!parentProp && value.__type_url) {
-        return value;
+        return;
       }
 
+      // Encoding an any type object
       if (!value.__type_url) {
         return;
       }

--- a/src/codec-protobuf.js
+++ b/src/codec-protobuf.js
@@ -81,6 +81,7 @@ export class Codec {
     this._options = {
       recursive: true,
       strict: true,
+      verify: true,
       ...options
     };
   }
@@ -150,7 +151,7 @@ export class Codec {
    * @return {Buffer}
    */
   encode (value) {
-    return this.encodeByType(value, this._rootTypeUrl);
+    return this.encodeByType(value, this._rootTypeUrl, this._options);
   }
 
   /**
@@ -160,9 +161,13 @@ export class Codec {
    * @param {string} [typeUrl]
    * @return {Buffer}
    */
-  encodeByType (value, typeUrl) {
+  encodeByType (value, typeUrl, options = { verify: true }) {
     if (this._modified) {
       this.build();
+    }
+
+    if (value.__type_url && typeUrl) {
+      throw new Error('Invalid __type_url in root message');
     }
 
     const type = this.getType(typeUrl);
@@ -170,27 +175,25 @@ export class Codec {
       throw new Error(`Unknown type: ${typeUrl}`);
     }
 
-    const object = this._iterate(type, value, null, (value, parentProp) => {
-      // If the prop doesn't exist in the schema, we must ignore it.
-      if (parentProp && !type.fields[parentProp]) {
-        return value;
-      }
-
+    const object = this._iterate(value, value => {
       // Encoding an any type object
       if (!value.__type_url) {
         return;
       }
 
-      if (!parentProp || type.fields[parentProp].type !== 'google.protobuf.Any') {
-        throw new Error(`Invalid __type_url for a non google.protobuf.Any: ${type.name}${parentProp ? '.' + parentProp : ''}`);
-      }
-
       const { __type_url: typeUrl, ...formalValue } = value;
       return {
         type_url: typeUrl,
-        value: this.encodeByType(formalValue, typeUrl)
+        value: this.encodeByType(formalValue, typeUrl, options)
       };
     });
+
+    if (options.verify) {
+      const err = type.verify(object);
+      if (err) {
+        throw Error(err);
+      }
+    }
 
     return type.encode(object).finish();
   }
@@ -255,7 +258,7 @@ export class Codec {
       }
     }
 
-    return this._iterate(type, value, null, value => {
+    return this._iterate(value, value => {
       // Test if already decoded.
       if (value.__type_url) {
         return value;
@@ -285,9 +288,7 @@ export class Codec {
 
   /**
    * Recursively traverses object.
-   * @param {Type} type
    * @param {*} value
-   * @param {string} parentProp
    * @param {IteratorCallback} callback
    * @return {Object}
    * @private
@@ -295,18 +296,17 @@ export class Codec {
    * Callback invoked via the visitor pattern `_iterate` which does custom encoding/decoding.
    * @callback IteratorCallback
    * @param {*} value
-   * @param {string} parentProp
    * @returns {Object|null}
    */
-  _iterate (type, value, parentProp, callback) {
+  _iterate (value, callback) {
     switch (Object.prototype.toString.call(value)) {
       // Object
       case '[object Object]': {
-        let result = callback(value, parentProp);
+        let result = callback(value);
         if (!result) {
           result = {};
           Object.keys(value).forEach(prop => {
-            result[prop] = this._iterate(type, value[prop], prop, callback);
+            result[prop] = this._iterate(value[prop], callback);
           });
         }
 
@@ -317,7 +317,7 @@ export class Codec {
       case '[object Array]': {
         const result = new Array(value.length);
         for (let i = 0; i < value.length; i++) {
-          result[i] = this._iterate(type, value[i], parentProp, callback);
+          result[i] = this._iterate(value[i], callback);
         }
 
         return result;

--- a/src/codec-protobuf.test.js
+++ b/src/codec-protobuf.test.js
@@ -154,7 +154,7 @@ test('should throw an error if try to use Any type in a non Any type message', (
     }
   };
 
-  expect(() => codec.encode(message)).toThrow('Invalid __type_url');
+  expect(() => codec.encode(message)).toThrow('customType.value: string expected');
 });
 
 test('should throw an error if the __type_url prop in the root object', () => {
@@ -164,4 +164,23 @@ test('should throw an error if the __type_url prop in the root object', () => {
   };
 
   expect(() => codec.encode(message)).toThrow('Invalid __type_url');
+});
+
+test('oneof', () => {
+  const message = {
+    oneofmessage: {
+      two: {
+        value: {
+          __type_url: 'testing.AnyNumber',
+          value: 1
+        }
+      }
+    }
+  };
+  expect(codec.decode(codec.encode(message))).toEqual(message);
+
+  delete message.oneofmessage.two;
+  message.oneofmessage.one = { value: 'test' };
+
+  expect(codec.decode(codec.encode(message))).toEqual(message);
 });

--- a/src/codec-protobuf.test.js
+++ b/src/codec-protobuf.test.js
@@ -160,19 +160,16 @@ test('should throw an error if try to use Any type in a non Any type message', (
 test('should ignore the __type_url prop in the root object', () => {
   const message = {
     bucketId: 'id1',
+    data: {
+      __type_url: 'testing.AnyNumber',
+      value: 1
+    },
     customType: {
       value: 'value1'
     }
   };
 
-  message.__type_url = 'wrong';
-
-  const buffer = codec.encode(message);
+  const buffer = codec.encode({ ...message, __type_url: 'wrong' });
   expect(buffer).toBeInstanceOf(Buffer);
-  expect(codec.decode(buffer)).toEqual({
-    bucketId: 'id1',
-    customType: {
-      value: 'value1'
-    }
-  });
+  expect(codec.decode(buffer)).toEqual(message);
 });

--- a/src/codec-protobuf.test.js
+++ b/src/codec-protobuf.test.js
@@ -124,10 +124,26 @@ test('ignore unknown props', () => {
       __type_url: 'testing.AnyNumber',
       value: 1
     },
+    customType: {
+      value: 'value1',
+      unknownType: {
+        unknownType: new Map()
+      }
+    },
     unknownType: new Map()
   };
 
-  expect(codec.encode(message)).toBeInstanceOf(Buffer);
+  const buffer = codec.encode(message);
+  expect(buffer).toBeInstanceOf(Buffer);
+  expect(codec.decode(buffer)).toEqual({
+    data: {
+      __type_url: 'testing.AnyNumber',
+      value: 1
+    },
+    customType: {
+      value: 'value1'
+    }
+  });
 });
 
 test('should throw an error if try to use Any type in a non Any type message', () => {
@@ -139,4 +155,24 @@ test('should throw an error if try to use Any type in a non Any type message', (
   };
 
   expect(() => codec.encode(message)).toThrow('Invalid __type_url');
+});
+
+test('should ignore the __type_url prop in the root object', () => {
+  const message = {
+    bucketId: 'id1',
+    customType: {
+      value: 'value1'
+    }
+  };
+
+  message.__type_url = 'wrong';
+
+  const buffer = codec.encode(message);
+  expect(buffer).toBeInstanceOf(Buffer);
+  expect(codec.decode(buffer)).toEqual({
+    bucketId: 'id1',
+    customType: {
+      value: 'value1'
+    }
+  });
 });

--- a/src/codec-protobuf.test.js
+++ b/src/codec-protobuf.test.js
@@ -157,19 +157,11 @@ test('should throw an error if try to use Any type in a non Any type message', (
   expect(() => codec.encode(message)).toThrow('Invalid __type_url');
 });
 
-test('should ignore the __type_url prop in the root object', () => {
+test('should throw an error if the __type_url prop in the root object', () => {
   const message = {
     bucketId: 'id1',
-    data: {
-      __type_url: 'testing.AnyNumber',
-      value: 1
-    },
-    customType: {
-      value: 'value1'
-    }
+    __type_url: 'wrong'
   };
 
-  const buffer = codec.encode({ ...message, __type_url: 'wrong' });
-  expect(buffer).toBeInstanceOf(Buffer);
-  expect(codec.decode(buffer)).toEqual(message);
+  expect(() => codec.encode(message)).toThrow('Invalid __type_url');
 });

--- a/src/testing/types.json
+++ b/src/testing/types.json
@@ -34,6 +34,10 @@
               "rule": "repeated",
               "type": "bytes",
               "id": 7
+            },
+            "oneofmessage": {
+              "type": "OneofMessage",
+              "id": 8
             }
           }
         },
@@ -55,6 +59,42 @@
               "rule": "repeated",
               "type": "bytes",
               "id": 4
+            }
+          }
+        },
+        "OneofMessage": {
+          "oneofs": {
+            "oneofvalue": {
+              "oneof": [
+                "one",
+                "two"
+              ]
+            }
+          },
+          "fields": {
+            "one": {
+              "type": "MessageOne",
+              "id": 1
+            },
+            "two": {
+              "type": "MessageTwo",
+              "id": 2
+            }
+          }
+        },
+        "MessageOne": {
+          "fields": {
+            "value": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "MessageTwo": {
+          "fields": {
+            "value": {
+              "type": "google.protobuf.Any",
+              "id": 1
             }
           }
         }

--- a/src/testing/types.proto
+++ b/src/testing/types.proto
@@ -16,6 +16,7 @@ message Container {
   repeated CustomType repeatedCustomType = 5;
   bytes dataBytes = 6;
   repeated bytes repeatedDataBytes = 7;
+  OneofMessage oneofmessage = 8;
 }
 
 message CustomType {
@@ -23,4 +24,19 @@ message CustomType {
   google.protobuf.Any data = 2;
   bytes dataBytes = 3;
   repeated bytes repeatedDataBytes = 4;
+}
+
+message OneofMessage {
+  oneof oneofvalue {
+    MessageOne one = 1;
+    MessageTwo two = 2;
+  }
+}
+
+message MessageOne {
+  string value = 1;
+}
+
+message MessageTwo {
+  google.protobuf.Any value = 1;
 }


### PR DESCRIPTION
- If the message has properties that doesn't belong to the schema it should ignore them instead of throw an error.
- I find several places in the credential package where they add `__type_url` in the root object, something not valid for this module and it was breaking the recursive iteration that's why I was deleting the prop before to start encoding but now instead i'm just ignoring it.
